### PR TITLE
color differentiation local vs imported

### DIFF
--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -289,7 +289,9 @@ export class DataService {
       } else {
         fetchTimeSeriesData(this.http, endpointKey, timeIntervals).subscribe((data: Series[]) => {
           for (const series of data) {
-            series.name = this.themeService.getEnergyTypeName(series.type, series.local) || series.name
+            series.type = this.themeService.getEnergyType(series.type, series.local) || series.type
+            series.name = this.themeService.getEnergyTypeName(series.type) || series.name
+            console.log("TYPE: " + series.type + " NAME " + series.name + " Local: " + series.local + " COLOR: " + this.themeService.colorMap.get(series.type))
             series.color = this.themeService.colorMap.get(series.type)
           }
           this.insertNewData(endpointKey, data, timeIntervals)

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -13,7 +13,7 @@ export class ThemeService {
   windOffshoreColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-3').trim();
   hydroPowerColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-4').trim();
   windOnshoreColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-5').trim();
-  solarColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-6').trim();
+  solarColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-12').trim();
   brownCoalColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-7').trim();
   naturalGasColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-8').trim();
   otherConventionalColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-9').trim();
@@ -21,6 +21,8 @@ export class ThemeService {
   pumpStorageColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-11').trim();
   importedEnergyRenewablesColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-19').trim();
   importedEnergyConventionalColor = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-20').trim();
+  solarColorLocal = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-6').trim();
+  biogasColorLocal = getComputedStyle(document.documentElement).getPropertyValue('--highcharts-color-21').trim();
 
   colors = [
     this.biogasColor,
@@ -35,6 +37,8 @@ export class ThemeService {
     this.otherConventionalColor,
     this.hardCoalColor,
     this.pumpStorageColor,
+    this.solarColorLocal,
+    this.biogasColorLocal,
   ]
 
   getColorIndex(type: string) {
@@ -60,6 +64,8 @@ export class ThemeService {
     ['total-external', this.otherConventionalColor],
     ['total-renewable', this.importedEnergyRenewablesColor],
     ['total-non-renewable', this.importedEnergyConventionalColor],
+    ['solar-local', this.solarColorLocal],
+    ['biogas-local', this.biogasColorLocal],
   ]);
 
   unitToName = new Map([
@@ -87,8 +93,11 @@ export class ThemeService {
     ['gas', 'Gas'],
   ])
 
-  getEnergyTypeName(type: string, local: boolean = false) {
-    return this.energyTypesToName.get(type + (local ? '-local' : ''))
+  getEnergyTypeName(type: string) {
+    return this.energyTypesToName.get(type)
+  }
 
+  getEnergyType(type: string, local: boolean = false){
+    return type + (local ? '-local' : '')
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,12 +56,14 @@ $frontend-theme: mat.define-light-theme((
 
 //colors for highcharts. Pallette: https://coolors.co/palette/f94144-f3722c-f8961e-f9844a-f9c74f-90be6d-43aa8b-4d908e-577590-277da1
 $hc-biogas: #90BE6D; 
+$hc-biogas-local: #709157; 
 $hc-biomas: #425f2c;
 $hc-other-renewables: #43AA8B; // other renewables
 $hc-wind-offshore: #4D908E; // wind off shore
 $hc-hydro-power: #277DA1; // hydro power
 $hc-wind-onshore: #577590; // wind onshore
-$hc-solar: #F9C74F; // solar
+$hc-solar-local: #F9C74F; // solar (local)
+$hc-solar-imported: #F8961E; // solar (imported)
 
 $hc-brown-coal: #db7c26; // braunkohle
 $hc-natural-gas: #bfbdc1; // natural gas
@@ -69,7 +71,7 @@ $hc-other-conventionals: #908e98; // other conventials
 $hc-hard-coal: #000000; // hard coal
 $hc-pump-storage: #3f3179; // pump storage
 
-$hc-orange-light: #F8961E;
+
 $hc-orange-medium: #F9844A;
 $hc-orange-dark: #F3722C;
 $hc-red: #F94144;
@@ -88,13 +90,13 @@ $hc-non-renewable-energy: #908e98; // Non-Renewable Energy
     --highcharts-color-3: #{$hc-wind-offshore};
     --highcharts-color-4: #{$hc-hydro-power};
     --highcharts-color-5: #{$hc-wind-onshore};
-    --highcharts-color-6: #{$hc-solar};
+    --highcharts-color-6: #{$hc-solar-local};
     --highcharts-color-7: #{$hc-brown-coal};
     --highcharts-color-8: #{$hc-natural-gas};
     --highcharts-color-9: #{$hc-other-conventionals};
     --highcharts-color-10: #{$hc-hard-coal};
     --highcharts-color-11: #{$hc-pump-storage};
-    --highcharts-color-12: #{$hc-orange-light};
+    --highcharts-color-12: #{$hc-solar-imported};
     --highcharts-color-13:#{$hc-orange-medium};
     --highcharts-color-14: #{$hc-orange-dark};
     --highcharts-color-15: #{$hc-red};
@@ -103,6 +105,7 @@ $hc-non-renewable-energy: #908e98; // Non-Renewable Energy
     --highcharts-color-18: #{$hc-mean-comparison-chart};
     --highcharts-color-19: #{$hc-renewable-energy};
     --highcharts-color-20: #{$hc-non-renewable-energy};
+    --highcharts-color-21: #{$hc-biogas-local};
 
     // this is currently only used for the average line in column charts
     --highcharts-neutral-color-40: #ff0000; 


### PR DESCRIPTION
Overview: 
Color and Type (local vs Imported) work correctly 
![Bildschirmfoto 2024-02-04 um 16 42 01](https://github.com/innoTUgrid/frontend/assets/53143036/c4cf4491-f500-4471-8b41-34f71bea90c1)

**Problem:** sankey diagram does not apply the colors defined in theming. The colors are correctly defined while loading sankey (see logs) but are not applied to the sankey diagram.

**Logs are correct:**
![Bildschirmfoto 2024-02-04 um 17 25 12](https://github.com/innoTUgrid/frontend/assets/53143036/6b5407cf-45ae-4b35-a9be-fcf15361ecfc)

**Colors are not applied in sankey:**
![Bildschirmfoto 2024-02-04 um 17 24 55](https://github.com/innoTUgrid/frontend/assets/53143036/adfb53ca-dc0d-4b1b-a1ea-c5b974843684)

@Tobiasloch Could you review this PR? Thanks!
